### PR TITLE
PLAT-61281: Add order field and sort by order

### DIFF
--- a/src/pages/docs/developer-guide/index.js
+++ b/src/pages/docs/developer-guide/index.js
@@ -58,6 +58,9 @@ export const devGuideQuery = graphql`
 				fields:{
 					slug: {regex: "/docs\\/developer-guide\\/[^/]*\/$/"}
 				}
+			},
+			sort: {
+				fields: [frontmatter___order, frontmatter___title], order: ASC
 			}
 		) {
 			...pageFields

--- a/src/pages/docs/developer-tools/index.js
+++ b/src/pages/docs/developer-tools/index.js
@@ -58,6 +58,9 @@ export const devToolsQuery = graphql`
 				fields:{
 					slug: {regex: "/docs\\/developer-tools\\/[^/]*\/$/"}
 				}
+			},
+			sort: {
+				fields: [frontmatter___order, frontmatter___title], order: ASC
 			}
 		) {
 			...pageFields

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -126,6 +126,9 @@ export const pageQuery = graphql`
 				fields:{
 					slug: {regex: "/docs\\/developer-guide\\/[^/]*\/$/"}
 				}
+			},
+			sort: {
+				fields: [frontmatter___order, frontmatter___title], order: ASC
 			}
 		) {
 			...pageFields
@@ -144,6 +147,9 @@ export const pageQuery = graphql`
 				fields:{
 					slug: {regex: "/docs\\/developer-tools\\/[^/]*\/$/"}
 				}
+			},
+			sort: {
+				fields: [frontmatter___order, frontmatter___title], order: ASC
 			}
 		) {
 			...pageFields
@@ -153,6 +159,9 @@ export const pageQuery = graphql`
 				fields:{
 					slug: {regex: "/docs\\/tutorials\\/[^/]*\/$/"}
 				}
+			},
+			sort: {
+				fields: [frontmatter___order, frontmatter___title], order: ASC
 			}
 		) {
 			...pageFields

--- a/src/pages/docs/tutorials/index.js
+++ b/src/pages/docs/tutorials/index.js
@@ -71,6 +71,9 @@ export const tutorialsQuery = graphql`
 				fields:{
 					slug: {regex: "/docs\\/tutorials\\/[^/]*\/$/"}
 				}
+			},
+			sort: {
+				fields: [frontmatter___order, frontmatter___title], order: ASC
 			}
 		) {
 			...pageFields

--- a/src/pages/docs/tutorials/introduction/index.md
+++ b/src/pages/docs/tutorials/introduction/index.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+order: 1
 ---
 
 This guide will help you learn the basics of Enact. Enact is a JavaScript framework built around the React UI library. You may have heard some things about React and how difficult it can be to learn. Relax. Part of the reason to use frameworks like Enact is to make it easier to get started by reducing the number of new concepts and tools that must be learned.

--- a/src/pages/docs/tutorials/setup/index.md
+++ b/src/pages/docs/tutorials/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Enact Development Setup
+order: 2
 ---
 Enact provides a handy command-line tool (the [Enact CLI](https://www.npmjs.com/package/@enact/cli)) that makes it easy to get started.
 

--- a/src/pages/docs/tutorials/tutorial-hello-enact/index.md
+++ b/src/pages/docs/tutorials/tutorial-hello-enact/index.md
@@ -1,5 +1,6 @@
 ---
 title: Hello Enact!
+order: 3
 ---
 ## Introduction
 Before you begin this tutorial, make sure you have created a new Enact project.  See [Enact Development Setup](../setup/) for more information.  You can delete `src/views/MainPanel.js` as it will not be used in the tutorial example.

--- a/src/pages/docs/tutorials/tutorial-kitten-browser/index.md
+++ b/src/pages/docs/tutorials/tutorial-kitten-browser/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kitten Browser
+order: 4
 ---
 ## Introduction
 Before you begin this tutorial, make sure you have created a new Enact project.  See [Enact Development Setup](../setup/) for more information.  You can delete `src/views/MainPanel.js` as it will not be used in the tutorial example.


### PR DESCRIPTION
- Add an order field to the frontmatter section to set the order of listing of markdown docs in the - various sections of the Developer Guide
- GraphQL queries to sort by order
- Added order to Tutorials

