### PR TITLE
ENYO-5107: Render and display constructor documentation

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -359,6 +359,7 @@
 
 		// Set margins on all of the top-level elements uniformly
 		p, pre,
+		.constructorClass,
 		.statics,
 		.properties,
 		.hocconfig {

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -78,11 +78,12 @@ const paramCountString = (params) => {
 	return result;
 };
 
-const renderFunction = (func, index) => {
+const renderFunction = (func, index, funcName) => {
 	const params = func.params || [];
 	const paramStr = buildParamList(params);
 	const parent = func.memberof ? func.memberof.match(/[^.]*\.(.*)/) : null;
-	const id = (parent ? parent[1] + '.' : '') + func.name;
+	const name = funcName ? funcName : func.name;
+	const id = (parent ? parent[1] + '.' : '') + name;
 	let returnType;
 
 	if (func.returns && func.returns.length && func.returns[0].type && func.returns[0].type.name) {
@@ -91,7 +92,7 @@ const renderFunction = (func, index) => {
 
 	return (
 		<section className={css.function} key={index}>
-			<dt id={id}>{func.name}(<var>{paramStr}</var>){returnType ? <span className={css.returnType}><Type>{returnType}</Type></span> : null}</dt>
+			<dt id={id}>{name}(<var>{paramStr}</var>){returnType ? <span className={css.returnType}><Type>{returnType}</Type></span> : null}</dt>
 			<DocParse component="dd">{func.description}</DocParse>
 			{(params.length || returnType) ?
 				<dd className={css.details}>
@@ -114,6 +115,21 @@ const renderFunction = (func, index) => {
 						</dl>
 					</div> : null}
 				</dd> : null}
+		</section>
+	);
+};
+
+export const renderConstructor = (member) => {
+	if (!member.constructorComment) {
+		return;
+	}
+
+	return (
+		<section className={css.constructorClass}>
+			<h5>Constructor</h5>
+			<dl>
+				{renderFunction(member.constructorComment, 1, member.name)}
+			</dl>
 		</section>
 	);
 };

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -8,7 +8,7 @@ import jsonata from 'jsonata';	// http://docs.jsonata.org/
 import kind from '@enact/core/kind';
 import PropTypes from 'prop-types';
 import React from 'react';
-import renderFunction from '../utils/functions.js';
+import renderFunction, {renderConstructor} from '../utils/functions.js';
 import {
 	renderInstanceProperties,
 	renderObjectProperties,
@@ -147,6 +147,7 @@ const renderModuleMember = (member, index) => {
 					{renderSeeTags(member)}
 				</div>
 				<ImportBlock module={member.memberof} name={member.name} />
+				{renderConstructor(member)}
 				{renderStaticProperties(member.members, isHoc)}
 				{renderInstanceProperties(member.members, isHoc)}
 			</section>;


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Render and display `constructor` documentation. Added an extra section for `constructor`


### Links
[//]: # (Related issues, references)
ENYO-5107

### Comments
Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com