### PR TITLE
ENYO-5475-3: Fixed Internal See Links

### DIFF
--- a/src/components/DocParse.js
+++ b/src/components/DocParse.js
@@ -18,7 +18,7 @@ function parseLink (child, index) {
 	const linkText = child.children[0].text || linkReference || title;
 	const url = child.url;
 
-	if (url) {
+	if (url.indexOf('http') === 0) {
 		return <OutboundLink href={url} key={index}>{linkText}</OutboundLink>;
 	} else if (title.indexOf('http') === 0) {
 		return <OutboundLink href={title} key={index}>{linkText}</OutboundLink>;
@@ -79,6 +79,8 @@ function parseChild (child, index) {
 			return <li key={index}>{parseChildren(child)}</li>;
 		case 'paragraph':
 			return <p key={index}>{parseChildren(child)}</p>;
+		case 'inline':
+			return <span key={index}>{parseChildren(child)}</span>;
 		case 'strong':
 			return <strong key={index}>{parseChildren(child)}</strong>;
 		case 'text':

--- a/src/components/See/See.less
+++ b/src/components/See/See.less
@@ -31,8 +31,4 @@
 		right: 0;
 		transform: translateX(100%);
 	}
-
-	p {
-		display: inline;
-	}
 }

--- a/src/utils/see.js
+++ b/src/utils/see.js
@@ -6,11 +6,21 @@ import DocParse from '../components/DocParse';
 
 export const renderSeeTags = (member) => {
 	const sees = member.sees || [];
-	return sees.map((tag, idx) => (
-		<DocParse key={idx} component={See}>
-			{tag}
-		</DocParse>
-	));
+	return sees.map((tag, idx) => {
+		// Convert paragraph tags to inline elements so they fit inside the See component properly.
+		if (tag.children) {
+			tag.children.map((child) => {
+				if (child.type === 'paragraph') {
+					child.type = 'inline';
+				}
+			});
+		}
+		return (
+			<DocParse key={idx} component={See}>
+				{tag}
+			</DocParse>
+		);
+	});
 };
 
 export default renderSeeTags;


### PR DESCRIPTION
Internal links were double-stacking URIs and were rendering as paragraphs.