### PR TITLE
ENYO-5855: Fix sample runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "html-webpack-plugin": "^2.28.0",
     "ilib-webpack-plugin": "~0.1.3",
     "json-loader": "^0.5.4",
-    "jsonata": "^1.6.3",
+    "jsonata": "1.5.4",
     "jsonfile": "^3.0.0",
     "less-loader": "^2.2.3",
     "lodash": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "html-webpack-plugin": "^2.28.0",
     "ilib-webpack-plugin": "~0.1.3",
     "json-loader": "^0.5.4",
-    "jsonata": "1.5.4",
+    "jsonata": "^1.6.4",
     "jsonfile": "^3.0.0",
     "less-loader": "^2.2.3",
     "lodash": "^4.15.0",

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -47,8 +47,9 @@ const hasUITag = (member) => {
 
 const getExampleTags = (member) => {
 	// Find any tag field whose `title` is 'example'
-	const expression = "$.tags[][title='example'][]";
-	return jsonata(expression).evaluate(member) || [];
+	// Updated style that works in jsonata 1.6.4 and always returns array!
+	const expression = "$.[tags[title='example']]";
+	return jsonata(expression).evaluate(member);
 };
 
 const getBaseComponents = (member) => {
@@ -294,5 +295,3 @@ export const renderModuleDescription = (doc) => {
 		</section>;
 	}
 };
-
-

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -54,14 +54,14 @@ const getExampleTags = (member) => {
 
 const getBaseComponents = (member) => {
 	// Find any tag field whose `title` is 'extends' and extract the name(s)
-	const expression = "$.tags[][title='extends'].name";
-	return jsonata(expression).evaluate(member) || [];
+	const expression = "$.[tags[title='extends'].name]";
+	return jsonata(expression).evaluate(member);
 };
 
 const getHocs = (member) => {
 	// Find any tag field whose `title` is 'mixes' and extract the name(s)
-	const expression = "$.tags[][title='mixes'].name";
-	return jsonata(expression).evaluate(member) || [];
+	const expression = "$.[tags[title='mixes'].name]";
+	return jsonata(expression).evaluate(member);
 };
 
 const MemberHeading = kind({


### PR DESCRIPTION
Issue: Sample runner was not pre-populating with sample code

Cause: Jsonata 1.6.1+ introduced a change in the way one of our expressions works.

Solution: Investigation showed that the expression sucked anyhow, so I updated it with one that works in both 1.5.4 and 1.6.1+.