### PR TITLE
PLAT-76385: Merge Analytics docs to 'docs' repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Copies of the source of Enact and other related libraries are placed into the `r
 ln -s ~/enact raw/enact
 ln -s ~/cli raw/cli
 ln -s ~/eslint-config-enact raw/eslint-config-enact
+ln -s ~/analytics raw/packages/analytics
 ```
 
 For linking built Enact runtime libraries, use the `enact link` command.

--- a/scripts/DocParser.js
+++ b/scripts/DocParser.js
@@ -272,7 +272,6 @@ function init () {
 	if (args.watch) {
 		let watcher = chokidar.watch(
 			['raw/enact', 'raw/packages'], // TODO: Only watching enact modules for now
-			// ['raw/enact'],	// TODO: Only watching enact for now
 			{
 				ignored: /(^|[/\\])\../,
 				persistent: true
@@ -280,7 +279,6 @@ function init () {
 		);
 		// TODO: Match pattern?
 		console.log('Watching "raw/enact" and "raw/packages" for changes...');	// eslint-disable-line no-console
-		// console.log('Watching "raw/enact" for changes...');	// eslint-disable-line no-console
 
 		watcher.on('change', path => {
 			const validFiles = getValidFiles(path);

--- a/scripts/DocParser.js
+++ b/scripts/DocParser.js
@@ -295,6 +295,11 @@ function init () {
 				getLibraryDescription: true
 			});
 			copyStaticDocs({
+				source: 'raw/packages/analytics/',
+				outputTo: 'src/pages/docs/modules/',
+				getLibraryDescription: true
+			});
+			copyStaticDocs({
 				source: 'raw/cli/',
 				outputTo: 'src/pages/docs/developer-tools/cli/'
 			});

--- a/scripts/DocParser.js
+++ b/scripts/DocParser.js
@@ -36,7 +36,7 @@ const allowedErrorTags = ['@hoc', '@hocconfig', '@ui', '@required', '@omit', '@t
 
 const getValidFiles = (pattern) => {
 	const searchPattern = pattern || '*.js';
-	const grepCmd = 'grep -r -l "@module" raw/enact/packages --exclude-dir build --exclude-dir node_modules --exclude-dir sampler --include=' + searchPattern;
+	const grepCmd = 'grep -r -l "@module" raw/enact/packages raw/packages --exclude-dir build --exclude-dir node_modules --exclude-dir sampler --include=' + searchPattern;
 	const moduleFiles = shelljs.exec(grepCmd, {silent: true});
 
 	return moduleFiles.stdout.trim().split('\n');
@@ -265,14 +265,16 @@ function init () {
 
 	if (args.watch) {
 		let watcher = chokidar.watch(
-			['raw/enact'],	// TODO: Only watching enact for now
+			['raw/enact', 'raw/packages'], // TODO: Only watching enact modules for now
+			// ['raw/enact'],	// TODO: Only watching enact for now
 			{
 				ignored: /(^|[/\\])\../,
 				persistent: true
 			}
 		);
 		// TODO: Match pattern?
-		console.log('Watching "raw/enact" for changes...');	// eslint-disable-line no-console
+		console.log('Watching "raw/enact" and "raw/packages" for changes...');	// eslint-disable-line no-console
+		// console.log('Watching "raw/enact" for changes...');	// eslint-disable-line no-console
 
 		watcher.on('change', path => {
 			const validFiles = getValidFiles(path);
@@ -299,6 +301,7 @@ function init () {
 				outputTo: 'src/pages/docs/modules/',
 				getLibraryDescription: true
 			});
+			// getDocumentation(getValidFiles(args.pattern)).then(generateIndex);
 			copyStaticDocs({
 				source: 'raw/cli/',
 				outputTo: 'src/pages/docs/developer-tools/cli/'

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -2,10 +2,10 @@ const shelljs = require('shelljs');
 shelljs.config.silent = true;
 
 const leaveIndex = (dir, basePath = 'src/pages/docs/') => {
-	// remove everything but leave dir's index.js/index.less
+	// remove everything but leave dir's index.js/index.module.less
 	const fullPath = basePath + dir;
 	const entries = shelljs.ls('-d', fullPath + '/*');
-	const matchIndex = new RegExp(`${fullPath}\/index\.(js|less)`);
+	const matchIndex = new RegExp(`${fullPath}\/index\.(js|module\.less)`);
 	entries.forEach(entry => {
 		if (!matchIndex.test(entry)) {
 			shelljs.rm('-r', entry);

--- a/scripts/prepareRaw.js
+++ b/scripts/prepareRaw.js
@@ -33,6 +33,7 @@ function copyGitHub (repo, destination, force, branch = 'master') {
 const args = parseArgs(process.argv);
 const rebuild = args['rebuild-raw'];
 
+copyGitHub('enactjs/analytics', 'raw/packages/analytics', rebuild, args['analytics-branch']);
 copyGitHub('enactjs/enact', 'raw/enact', rebuild, args['enact-branch']);
 copyGitHub('enactjs/cli', 'raw/cli', rebuild, args['cli-branch']);
 copyGitHub('enactjs/eslint-config-enact', 'raw/eslint-config-enact', rebuild, args['eslint-config-branch']);

--- a/src/components/ModulesList/ModulesList.js
+++ b/src/components/ModulesList/ModulesList.js
@@ -55,12 +55,13 @@ const ModulesListBase = kind({
 					componentDocs.forEach((page) => {
 						// Compartmentalize <li>s inside the parent UL
 						const subLinkText = page.node.fields.slug.replace('/docs/modules/', '').replace(/\/$/, '');
-						const [subLibrary, subDoc = subLibrary] = subLinkText.split('/');
+						// for some modules (ex. analytics) there is documentation for modules deeper in the tree
+						const [subLibrary, subDoc = subLibrary, altSubDoc = ''] = subLinkText.split('/');
 						const activePage = linkIsLocation(page.node.fields.slug, location.pathname);
 						if (subLibrary === library) {
 							children.push({
 								active: activePage,
-								title: (useFullModulePath ? subLinkText : subDoc),
+								title: useFullModulePath ? subLinkText : altSubDoc ? altSubDoc : subDoc,
 								to: page.node.fields.slug
 							});
 						}

--- a/src/pages/docs/modules/index.js
+++ b/src/pages/docs/modules/index.js
@@ -14,6 +14,7 @@ import componentCss from './index.module.less';
 // images
 import modules from '../images/modules.svg';
 // package images
+import analytics from '../images/package-webos.svg';
 import core from '../images/package-core.svg';
 import i18n from '../images/package-i18n.svg';
 import moonstone from '../images/package-moonstone.svg';
@@ -24,6 +25,7 @@ import webos from '../images/package-webos.svg';
 const {docVersion} = versionData;
 
 const packageImages = {
+	analytics,
 	core,
 	i18n,
 	moonstone,


### PR DESCRIPTION
`analytics` is an "external" module in that it isn't in the normal Enact module directory, but provides inline documentation that we want to render in the module pages.  Therefore, the doc parser and raw preparation scripts need to be able to handle it.