### PR TITLE
Add warning for duplicate keys

### DIFF
--- a/scripts/DocParser.js
+++ b/scripts/DocParser.js
@@ -122,6 +122,18 @@ function validate (docs, name, componentDirectory, strict) {
 	} else {
 		warn(`\nFirst item not a module: ${docs[0].path[0].name} (${docs[0].path[0].kind}) in ${docNameAndPosition(docs[0])}`);
 	}
+
+	if (docs[0].members && docs[0].members.static.length) {
+		const uniques = {};
+		docs[0].members.static.forEach(member => {
+			const name = member.name;
+			if (uniques[name]) {
+				warn(`\nDuplicate module member ${docNameAndPosition(member)}, original: ${docNameAndPosition(uniques[name])}`);
+			} else {
+				uniques[name] = member;
+			}
+		});
+	}
 }
 
 function copyStaticDocs ({source, outputTo: outputBase, getLibraryDescription = false}) {


### PR DESCRIPTION
Only does so for static members at the module level but could be adapted to check more members and at a deeper level, if desired

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com