### PR TITLE
ENYO-5646: Add floating anchors to allow deep linking

### DIFF
--- a/src/components/FloatingAnchor/FloatingAnchor.js
+++ b/src/components/FloatingAnchor/FloatingAnchor.js
@@ -27,7 +27,7 @@ const FloatingAnchor = kind({
 
 			return (
 				<a href={`#${id}`} className={css.anchor}>
-					<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">
+					<svg className={css.icon} aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">
 						<path fillRule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z" />
 					</svg>
 				</a>

--- a/src/components/FloatingAnchor/FloatingAnchor.js
+++ b/src/components/FloatingAnchor/FloatingAnchor.js
@@ -13,7 +13,12 @@ const FloatingAnchor = kind({
 			PropTypes.func
 		]).isRequired,
 		children: PropTypes.node,
-		id: PropTypes.string
+		id: PropTypes.string,
+		inline: PropTypes.bool
+	},
+
+	defaultProps: {
+		inline: false
 	},
 
 	styles: {
@@ -32,7 +37,8 @@ const FloatingAnchor = kind({
 					</svg>
 				</a>
 			);
-		}
+		},
+		className: ({inline, styler}) => styler.append({floating: !inline})
 	},
 
 	render: ({anchor, children, component: Component, ...rest}) => {

--- a/src/components/FloatingAnchor/FloatingAnchor.js
+++ b/src/components/FloatingAnchor/FloatingAnchor.js
@@ -1,0 +1,51 @@
+import kind from '@enact/core/kind';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import css from './FloatingAnchor.module.less';
+
+const FloatingAnchor = kind({
+	name: 'FloatingAnchor',
+
+	propTypes: {
+		component: PropTypes.oneOf([
+			PropTypes.string,
+			PropTypes.func
+		]).isRequired,
+		children: PropTypes.node,
+		id: PropTypes.string
+	},
+
+	styles: {
+		css,
+		className: 'floatingAnchor'
+	},
+
+	computed: {
+		anchor: ({id}) => {
+			if (!id) return null;
+
+			return (
+				<a href={`#${id}`} className={css.anchor}>
+					<svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">
+						<path fillRule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z" />
+					</svg>
+				</a>
+			);
+		}
+	},
+
+	render: ({anchor, children, component: Component, ...rest}) => {
+		return (
+			<Component {...rest}>
+				{anchor}
+				{children}
+			</Component>
+		);
+	}
+});
+
+export default FloatingAnchor;
+export {
+	FloatingAnchor
+};

--- a/src/components/FloatingAnchor/FloatingAnchor.module.less
+++ b/src/components/FloatingAnchor/FloatingAnchor.module.less
@@ -1,17 +1,18 @@
-.floatingAnchor {
-    position: relative;
+@import "../../css/variables.less";
 
+.floatingAnchor {
     .anchor {
         float: left;
-        margin-left: -20px;
+        margin-left: -@docs-anchor-width;
+        padding-right: 4px;
 
-        SVG {
+        .icon {
             visibility: hidden;
             vertical-align: middle;
         }
     }
 
-    &:hover .anchor SVG {
+    &:hover .anchor .icon {
         visibility: visible;
     }
 }

--- a/src/components/FloatingAnchor/FloatingAnchor.module.less
+++ b/src/components/FloatingAnchor/FloatingAnchor.module.less
@@ -2,14 +2,17 @@
 
 .floatingAnchor {
     .anchor {
-        float: left;
-        margin-left: -@docs-anchor-width;
         padding-right: 4px;
 
         .icon {
             visibility: hidden;
             vertical-align: middle;
         }
+    }
+
+    &.floating .anchor {
+        float: left;
+        margin-left: -@docs-anchor-width;
     }
 
     &:hover .anchor .icon {

--- a/src/components/FloatingAnchor/FloatingAnchor.module.less
+++ b/src/components/FloatingAnchor/FloatingAnchor.module.less
@@ -1,0 +1,17 @@
+.floatingAnchor {
+    position: relative;
+
+    .anchor {
+        float: left;
+        margin-left: -20px;
+
+        SVG {
+            visibility: hidden;
+            vertical-align: middle;
+        }
+    }
+
+    &:hover .anchor SVG {
+        visibility: visible;
+    }
+}

--- a/src/components/FloatingAnchor/package.json
+++ b/src/components/FloatingAnchor/package.json
@@ -1,0 +1,3 @@
+{
+    "main": "FloatingAnchor.js"
+}

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -28,7 +28,6 @@ const PageBase = kind({
 		layout: PropTypes.any,
 		layoutContext: PropTypes.any,
 		location: PropTypes.object,
-		manualLayout: PropTypes.bool,
 		match: PropTypes.any,
 
 		// Ours
@@ -55,7 +54,6 @@ const PageBase = kind({
 	},
 
 	defaultProps: {
-		manualLayout: false,
 		scrolled: false,
 		sidebar: false
 		// title: 'no title - something\'s not right'
@@ -67,7 +65,6 @@ const PageBase = kind({
 	},
 
 	computed: {
-		children: ({children, manualLayout}) => (manualLayout ? children : <SiteSection>{children}</SiteSection>),
 		navProps: ({nav, data, location}) => {
 			if (nav) {
 				return {
@@ -87,7 +84,6 @@ const PageBase = kind({
 		delete rest.layout;
 		delete rest.layoutContext;
 		// delete rest.location;
-		delete rest.manualLayout;
 		delete rest.match;
 		delete rest.page;
 		delete rest.pageResources;

--- a/src/components/Page/Page.module.less
+++ b/src/components/Page/Page.module.less
@@ -22,7 +22,7 @@
 }
 
 .page {
-	@docs-sidebar-margin: 6%;
+	@docs-sidebar-margin: @docs-site-edge-keepout + @docs-anchor-width;
 
 	// The way the layout works
 	//
@@ -66,7 +66,7 @@
 			margin: 0 @docs-sidebar-margin 1ex 0;
 			border-right: 1px solid @docs-sidebar-border-color;
 			color: fade(black, 60%);
-			padding: 4em 2ex 1ex 0;
+			padding: 4em @docs-site-edge-keepout 1ex 0;
 			transition: 0.5s transform ease-in-out;
 
 			&:hover {

--- a/src/css/main.module.less
+++ b/src/css/main.module.less
@@ -250,7 +250,6 @@
 	section.module {
 		border-radius: @docs-module-padding;
 		margin-bottom: 1em;
-		overflow: hidden;	// To support margins on internal components
 
 		// Set margins on all of the top-level elements uniformly
 		p, pre,

--- a/src/css/main.module.less
+++ b/src/css/main.module.less
@@ -250,6 +250,7 @@
 	section.module {
 		border-radius: @docs-module-padding;
 		margin-bottom: 1em;
+		overflow: hidden;	// To support margins on internal components
 
 		// Set margins on all of the top-level elements uniformly
 		p, pre,
@@ -305,13 +306,6 @@
 				}
 			}
 		}
-		&.function {
-			dl {
-				display: block;
-				margin-left: @docs-module-padding;
-				margin-right: @docs-module-padding;
-			}
-		}
 		h5 {
 			color: @docs-color-accent2;
 			border-bottom: 1px solid;
@@ -348,7 +342,9 @@
 		}
 
 		dl {
-			display: table;
+			display: block;
+			margin-left: @docs-anchor-width;
+			margin-right: @docs-module-padding;
 			width: 100%;
 
 			> .section > .title,

--- a/src/css/main.module.less
+++ b/src/css/main.module.less
@@ -391,135 +391,153 @@
 					display: none;
 				}
 			}
+		}
 
-			section.function,
-			section.property > * {
-				border-top: 1px solid fade(black, 5%);
-				padding-top: 0.5em;
-				padding-bottom: 1em;
+		section.function,
+		section.property > * {
+			border-top: 1px solid fade(black, 5%);
+			padding-top: 0.5em;
+			padding-bottom: 1em;
+		}
+		section.function:first-child,
+		section.property:first-child > * {
+			border-top-width: 0;
+		}
+
+		section.function,
+		section.exportedFunction {
+			@sub-table-indent: @docs-module-padding * 3;
+
+			display: block;
+
+			h6 {
+				margin: 0 0 0 @sub-table-indent;
+				font-style: italic;
+				color: white;
+				background-color: @docs-color-accent1;
+				display: inline-block;
+				padding: 0 1em;
+				line-height: 130%;
+				vertical-align: bottom;
+				border-top-left-radius: 6px;
+				border-top-right-radius: 6px;
 			}
-			section.function:first-child,
-			section.property:first-child > * {
-				border-top-width: 0;
-			}
-
-			section.function {
-				@sub-table-indent: @docs-module-padding * 3;
-
+			dt {
 				display: block;
+			}
+			dd {
 
-				h6 {
-					margin: 0 0 0 @sub-table-indent;
-					font-style: italic;
-					color: white;
-					background-color: @docs-color-accent1;
-					display: inline-block;
-					padding: 0 1em;
-					line-height: 130%;
-					vertical-align: bottom;
-					border-top-left-radius: 6px;
-					border-top-right-radius: 6px;
-				}
-				dt {
-					display: block;
-				}
-				dd {
+				&.details {
+					display: flex;
+					margin-left: (@docs-module-padding * 2);
+					margin-right: (@docs-module-padding * 2);
 
-					&.details {
-						display: flex;
-						margin-left: (@docs-module-padding * 2);
-						margin-right: (@docs-module-padding * 2);
+					.params,
+					.returns {
+						flex: 1 1 50%;
+						margin-bottom: 1em;
 
-						.params,
-						.returns {
-							flex: 1 1 50%;
-							margin-bottom: 1em;
+						h6 {
+							margin-left: 0;
+						}
+						dl {
+							display: block;
+							margin: 0;
+							padding: @docs-module-padding;
 
-							h6 {
-								margin-left: 0;
-							}
+							// Enumerated prop objects
 							dl {
-								display: block;
-								margin: 0;
-								padding: @docs-module-padding;
+								padding: 0;
+								border-left: 3px solid @docs-color-accent1;
 
-								// Enumerated prop objects
-								dl {
-									padding: 0;
-									border-left: 3px solid @docs-color-accent1;
+								dt {
+									padding-left: 12px;
+									border-top: 1px dotted;
 
-									dt {
-										padding-left: 12px;
-										border-top: 1px dotted;
-
-										&:first-child {
-											border-top-style: none;
-										}
+									&:first-child {
+										border-top-style: none;
 									}
-									dd {
-										p {
-											margin-bottom: 0.5em;
-										}
+								}
+								dd {
+									p {
+										margin-bottom: 0.5em;
 									}
 								}
 							}
-							dt {
-								color: @docs-color-accent1;
-							}
 						}
-						.params dl {
-							background-color: fade(@docs-color-accent1, 10%);
+						dt {
+							color: @docs-color-accent1;
 						}
-						.returns {
-							// a {
-							// 	color: inherit;
-							// }
-							h6 {
-								background-color: @docs-color-accent2;
-							}
+					}
+					.params dl {
+						background-color: fade(@docs-color-accent1, 10%);
+					}
+					.returns {
+						// a {
+						// 	color: inherit;
+						// }
+						h6 {
+							background-color: @docs-color-accent2;
+						}
+						dl {
+							border-top-color: @docs-color-accent2;
+							background-color: fade(@docs-color-accent2, 10%);
+
 							dl {
-								border-top-color: @docs-color-accent2;
-								background-color: fade(@docs-color-accent2, 10%);
-
-								dl {
-									border-left-color: @docs-color-accent2;
-								}
-							}
-						}
-						> * {
-							margin-left: (@docs-module-padding * 2);
-
-							&:first-child {
-								margin-left: 0;
-							}
-							dl:last-child {
-								border-bottom-left-radius: 6px;
-								border-bottom-right-radius: 6px;
+								border-left-color: @docs-color-accent2;
 							}
 						}
 					}
-				}
-				dl {
-					margin: 0 0 1em @sub-table-indent;
-					border-top: 1px solid @docs-color-accent1;
-				}
+					> * {
+						margin-left: (@docs-module-padding * 2);
 
-				.returnType {
-					&::before {
-						content: '\2192';	// &rarr; - right arrow
-						// content: '\21D2';	// &rarr; - double right arrow
-						display: inline;
-						margin: 0 1ex;
+						&:first-child {
+							margin-left: 0;
+						}
+						dl:last-child {
+							border-bottom-left-radius: 6px;
+							border-bottom-right-radius: 6px;
+						}
 					}
 				}
 			}
-			section.property {
-				display: table-row;
+			dl {
+				margin: 0 0 1em @sub-table-indent;
+				border-top: 1px solid @docs-color-accent1;
+			}
 
-				.details {
-					padding-left: 4ex;
-					padding-bottom: 0.2em;
+			.returnType {
+				&::before {
+					content: '\2192';	// &rarr; - right arrow
+					// content: '\21D2';	// &rarr; - double right arrow
+					display: inline;
+					margin: 0 1ex;
 				}
+			}
+		}
+
+		section.exportedFunction {
+			// Function signature code block
+			.signature {
+				display: block;
+				margin: @docs-site-edge-keepout 0;
+
+				var {
+					font-style: italic;
+				}
+			}
+
+			dd.details {
+				margin: 0;
+			}
+		}
+
+		section.property {
+			display: table-row;
+
+			.details {
+				padding-left: 4ex;
+				padding-bottom: 0.2em;
 			}
 		}
 

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -2,7 +2,7 @@
 //
 
 @docs-site-max-width: 960px;
-@docs-site-edge-keepout: 15px;
+@docs-site-edge-keepout: 24px;
 @docs-module-padding: 12px;
 @docs-anchor-width: 20px;
 

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -4,6 +4,7 @@
 @docs-site-max-width: 960px;
 @docs-site-edge-keepout: 15px;
 @docs-module-padding: 12px;
+@docs-anchor-width: 20px;
 
 @docs-header-logo-image-size: 100px;
 @docs-header-item-spacing: 10px;

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -14,7 +14,6 @@ export default class IndexLayout extends React.Component {
 		return (
 			<Page
 				// title={rest.data.site.siteMetadata.title}
-				manualLayout
 				{...rest}
 			>
 				{children()}

--- a/src/pages/docs/developer-guide/index.js
+++ b/src/pages/docs/developer-guide/index.js
@@ -4,6 +4,7 @@ import {Row} from '@enact/ui/Layout';
 
 import {CellLink} from '../../../components/LinkBox';
 import SiteTitle from '../../../components/SiteTitle';
+import SiteSection from '../../../components/SiteSection';
 
 import css from '../../../css/main.module.less';
 
@@ -25,7 +26,7 @@ const Doc = class ReduxDocList extends React.Component {
 
 		return (
 			<SiteTitle {...this.props} title={frontmatter.title}>
-				<div className="covertLinks">
+				<SiteSection className="covertLinks">
 					<h1 className={css.withCaption}><img alt="Location marked in a book" src={guide} />{frontmatter.title}</h1>
 					<div className={css.caption}>
 						<p>Details and resources on how to use Enact.</p>
@@ -40,7 +41,7 @@ const Doc = class ReduxDocList extends React.Component {
 							);
 						})}
 					</Row>
-				</div>
+				</SiteSection>
 			</SiteTitle>
 		);
 	}

--- a/src/pages/docs/developer-tools/index.js
+++ b/src/pages/docs/developer-tools/index.js
@@ -4,6 +4,7 @@ import {Row} from '@enact/ui/Layout';
 
 import {CellLink} from '../../../components/LinkBox';
 import SiteTitle from '../../../components/SiteTitle';
+import SiteSection from '../../../components/SiteSection';
 
 import css from '../../../css/main.module.less';
 
@@ -25,7 +26,7 @@ const Doc = class ReduxDocList extends React.Component {
 
 		return (
 			<SiteTitle {...this.props} title={frontmatter.title}>
-				<div className={css.moduleBody + ' covertLinks'}>
+				<SiteSection className={css.moduleBody + ' covertLinks'}>
 					<h1 className={css.withCaption}><img alt="A wrench fixing a book" src={devTools} />{frontmatter.title}</h1>
 					<div className={css.caption}>
 						<p>Enact tools that make life easier.</p>
@@ -40,7 +41,7 @@ const Doc = class ReduxDocList extends React.Component {
 							);
 						})}
 					</Row>
-				</div>
+				</SiteSection>
 			</SiteTitle>
 		);
 	}

--- a/src/pages/docs/modules/index.js
+++ b/src/pages/docs/modules/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {Row} from '@enact/ui/Layout';
 import GridItem from '../../../components/GridItem';
+import SiteSection from '../../../components/SiteSection';
 import SiteTitle from '../../../components/SiteTitle';
 
 import libraryDescription from '../../../data/libraryDescription.json';
@@ -51,7 +52,7 @@ const Doc = class ReduxDocList extends React.Component {
 
 		return (
 			<SiteTitle {...this.props} title={frontmatter.titleWithVersion}>
-				<div className={css.libraryList + ' covertLinks'}>
+				<SiteSection className={css.libraryList + ' covertLinks'}>
 					<h1 className={css.withCaption}><img alt="Building blocks" src={modules} />{frontmatter.title}</h1>
 					<div className={css.caption}>
 						<p>Select a library to explore the Enact API for version {docVersion}</p>
@@ -71,7 +72,7 @@ const Doc = class ReduxDocList extends React.Component {
 							}
 						})}
 					</Row>
-				</div>
+				</SiteSection>
 			</SiteTitle>
 		);
 	}

--- a/src/pages/docs/tutorials/index.js
+++ b/src/pages/docs/tutorials/index.js
@@ -2,8 +2,9 @@ import {Column} from '@enact/ui/Layout';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import SiteTitle from '../../../components/SiteTitle';
 import {CellLink} from '../../../components/LinkBox';
+import SiteSection from '../../../components/SiteSection';
+import SiteTitle from '../../../components/SiteTitle';
 
 import css from '../../../css/main.module.less';
 
@@ -24,7 +25,7 @@ const Doc = class ReduxDocList extends React.Component {
 		const componentDocs = this.props.data.tutorialsList.edges;
 		return (
 			<SiteTitle {...this.props} title={frontmatter.title}>
-				<div className="covertLinks">
+				<SiteSection className="covertLinks">
 					<h1 className={css.withCaption}><img alt="Look in a book" src={tutorials} />{frontmatter.title}</h1>
 					<div className={css.caption}>
 						<p>Here you can learn the basics of Enact. Enact is a JavaScript
@@ -52,7 +53,7 @@ const Doc = class ReduxDocList extends React.Component {
 							);
 						})}
 					</Column>
-				</div>
+				</SiteSection>
 			</SiteTitle>
 		);
 	}

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -97,50 +97,79 @@ const renderProperties = (param) => {
 	}
 };
 
+// eslint-disable-next-line enact/prop-types
+const Parameters = ({func, params, returnType}) => {
+	if (params.length === 0 && !returnType) return null;
+
+	return (
+		<dd className={css.details}>
+			{params.length ? <div className={css.params}>
+				<h6>{paramCountString(params)}</h6>
+				{params.map((param, subIndex) => (
+					<dl key={subIndex}>
+						<dt>{param.name} {renderParamTypeStrings(param)}</dt>
+						{paramIsOptional(param) ? <dt className={css.optional}>optional</dt> : null}
+						{param.default ? <dt className={css.default}>default: {param.default}</dt> : null}
+						<DocParse component="dd">
+							{param.description}
+						</DocParse>
+						{renderProperties(param)}
+					</dl>
+				))}
+			</div> : null}
+			{returnType ? <div className={css.returns}>
+				<h6>Returns</h6>
+				<dl>
+					<dt>{renderType(returnType)}</dt>
+					<DocParse component="dd">{func.returns[0].description}</DocParse>
+				</dl>
+			</div> : null}
+		</dd>
+	);
+};
+
+const getReturnType = (func) => {
+	if (func.returns && func.returns.length && func.returns[0].type) {
+		if (func.returns[0].type.name) {
+			return func.returns[0].type.name;
+		} else if (func.returns[0].type.expression) {
+			return func.returns[0].type.expression.name;
+		}
+	}
+};
+
+export const renderExportedFunction = (func) => {
+	const params = func.params || [];
+	const paramStr = buildParamList(params);
+	const name = func.name;
+	const returnType = getReturnType(func);
+
+	return (
+		<section className={css.exportedFunction}>
+			<pre className={css.signature}>
+				<code>
+					{name}( <var>{paramStr}</var> ){returnType ? <span className={css.returnType}>{returnType}</span> : null}
+				</code>
+			</pre>
+			<DocParse>{func.description}</DocParse>
+			<Parameters func={func} params={params} returnType={returnType} />
+		</section>
+	);
+};
+
 const renderFunction = (func, index, funcName) => {
 	const params = func.params || [];
 	const paramStr = buildParamList(params);
 	const parent = func.memberof ? func.memberof.match(/[^.]*\.(.*)/) : null;
 	const name = funcName ? funcName : func.name;
 	const id = (parent ? parent[1] + '.' : '') + name;
-	let returnType;
-
-	if (func.returns && func.returns.length && func.returns[0].type) {
-		if (func.returns[0].type.name) {
-			returnType = func.returns[0].type.name;
-		} else if (func.returns[0].type.expression) {
-			returnType = func.returns[0].type.expression.name;
-		}
-	}
+	const returnType = getReturnType(func);
 
 	return (
 		<section className={css.function} key={index}>
 			<DefTerm id={id}>{name}(<var>{paramStr}</var>){returnType ? <span className={css.returnType}><Type>{returnType}</Type></span> : null}</DefTerm>
 			<DocParse component="dd">{func.description}</DocParse>
-			{(params.length || returnType) ?
-				<dd className={css.details}>
-					{params.length ? <div className={css.params}>
-						<h6>{paramCountString(params)}</h6>
-						{params.map((param, subIndex) => (
-							<dl key={subIndex}>
-								<dt>{param.name} {renderParamTypeStrings(param)}</dt>
-								{paramIsOptional(param) ? <dt className={css.optional}>optional</dt> : null}
-								{param.default ? <dt className={css.default}>default: {param.default}</dt> : null}
-								<DocParse component="dd">
-									{param.description}
-								</DocParse>
-								{renderProperties(param)}
-							</dl>
-						))}
-					</div> : null}
-					{returnType ? <div className={css.returns}>
-						<h6>Returns</h6>
-						<dl>
-							<dt>{renderType(returnType)}</dt>
-							<DocParse component="dd">{func.returns[0].description}</DocParse>
-						</dl>
-					</div> : null}
-				</dd> : null}
+			<Parameters func={func} params={params} returnType={returnType} />
 		</section>
 	);
 };

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -2,9 +2,12 @@
 // as part of /wrappers/json.js
 
 import DocParse from '../components/DocParse.js';
+import FloatingAnchor from '../components/FloatingAnchor';
 import jsonata from 'jsonata';	// http://docs.jsonata.org/
 import React from 'react';
 import Type from '../components/Type';
+
+const DefTerm = (props) => FloatingAnchor.inline({component: 'dt', ...props});
 
 import {renderType, jsonataTypeParser} from './types';
 
@@ -112,7 +115,7 @@ const renderFunction = (func, index, funcName) => {
 
 	return (
 		<section className={css.function} key={index}>
-			<dt id={id}>{name}(<var>{paramStr}</var>){returnType ? <span className={css.returnType}><Type>{returnType}</Type></span> : null}</dt>
+			<DefTerm id={id}>{name}(<var>{paramStr}</var>){returnType ? <span className={css.returnType}><Type>{returnType}</Type></span> : null}</DefTerm>
 			<DocParse component="dd">{func.description}</DocParse>
 			{(params.length || returnType) ?
 				<dd className={css.details}>

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -8,7 +8,7 @@ import React from 'react';
 
 import DocParse from '../components/DocParse.js';
 import EnactLive from '../components/EnactLiveEdit.js';
-import renderFunction, {renderConstructor} from '../utils/functions.js';
+import {renderExportedFunction, renderConstructor} from '../utils/functions.js';
 import {
 	renderInstanceProperties,
 	renderObjectProperties,
@@ -150,13 +150,10 @@ const renderModuleMember = (member, index) => {
 
 	switch (memberKind) {
 		case 'function':
-			classes.push(css.function);
 			return <section className={classes.join(' ')} key={index}>
 				<MemberHeading varType="Function" deprecated={isDeprecated}>{member.name}</MemberHeading>
 				{deprecationNote}
-				<dl>
-					{renderFunction(member)}
-				</dl>
+				{renderExportedFunction(member)}
 			</section>;
 		case 'constant':
 			return <section className={classes.join(' ')} key={index}>

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -8,6 +8,7 @@ import React from 'react';
 
 import DocParse from '../components/DocParse.js';
 import EnactLive from '../components/EnactLiveEdit.js';
+import FloatingAnchor from '../components/FloatingAnchor';
 import renderFunction, {renderConstructor} from '../utils/functions.js';
 import {
 	renderInstanceProperties,
@@ -23,6 +24,8 @@ import Code from '../components/Code';
 import {hasDeprecatedTag} from './common';
 
 import css from '../css/main.module.less';
+
+const H4 = (props) => FloatingAnchor.inline({component: 'h4', ...props});
 
 const hasFactoryTag = (member) => {
 	// Find any tag field whose `title` is 'factory'
@@ -84,11 +87,11 @@ const MemberHeading = kind({
 	render: ({children, deprecationIcon, uniqueId, varType, ...rest}) => {
 		delete rest.deprecated;
 		return (
-			<h4 {...rest} id={uniqueId}>
+			<H4 {...rest} id={uniqueId}>
 				{children}
 				{varType}
 				{deprecationIcon}
-			</h4>
+			</H4>
 		);
 	}
 });

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -16,6 +16,7 @@ import {
 } from '../utils/properties.js';
 import renderSeeTags from '../utils/see';
 import renderTypedef from '../utils/typedefs';
+import FloatingAnchor from '../components/FloatingAnchor';
 import SmartLink from '../components/SmartLink';
 import Type from '../components/Type';
 import Code from '../components/Code';
@@ -23,6 +24,8 @@ import Code from '../components/Code';
 import {hasDeprecatedTag} from './common';
 
 import css from '../css/main.module.less';
+
+const H4 = (props) => FloatingAnchor.inline({component: 'h4', ...props});
 
 const hasFactoryTag = (member) => {
 	// Find any tag field whose `title` is 'factory'
@@ -84,11 +87,11 @@ const MemberHeading = kind({
 	render: ({children, deprecationIcon, uniqueId, varType, ...rest}) => {
 		delete rest.deprecated;
 		return (
-			<h4 {...rest} id={uniqueId}>
+			<H4 {...rest} id={uniqueId}>
 				{children}
 				{varType}
 				{deprecationIcon}
-			</h4>
+			</H4>
 		);
 	}
 });

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -8,7 +8,6 @@ import React from 'react';
 
 import DocParse from '../components/DocParse.js';
 import EnactLive from '../components/EnactLiveEdit.js';
-import FloatingAnchor from '../components/FloatingAnchor';
 import renderFunction, {renderConstructor} from '../utils/functions.js';
 import {
 	renderInstanceProperties,
@@ -24,8 +23,6 @@ import Code from '../components/Code';
 import {hasDeprecatedTag} from './common';
 
 import css from '../css/main.module.less';
-
-const H4 = (props) => FloatingAnchor.inline({component: 'h4', ...props});
 
 const hasFactoryTag = (member) => {
 	// Find any tag field whose `title` is 'factory'
@@ -87,11 +84,11 @@ const MemberHeading = kind({
 	render: ({children, deprecationIcon, uniqueId, varType, ...rest}) => {
 		delete rest.deprecated;
 		return (
-			<H4 {...rest} id={uniqueId}>
+			<h4 {...rest} id={uniqueId}>
 				{children}
 				{varType}
 				{deprecationIcon}
-			</H4>
+			</h4>
 		);
 	}
 });

--- a/src/utils/properties.js
+++ b/src/utils/properties.js
@@ -5,6 +5,7 @@ import DocParse from '../components/DocParse.js';
 import jsonata from 'jsonata';	// http://docs.jsonata.org/
 import React from 'react';
 
+import FloatingAnchor from '../components/FloatingAnchor';
 import {renderDefaultTag, processDefaultTag, hasRequiredTag, hasDeprecatedTag} from './common';
 import renderFunction from './functions';
 import renderSeeTags from '../utils/see';
@@ -12,6 +13,8 @@ import {renderType, jsonataTypeParser} from './types';
 import {renderTypedefProp} from './typedefs.js';
 
 import css from '../css/main.module.less';
+
+const Section = (props) => FloatingAnchor.inline({component: 'section', ...props});
 
 const processTypeTag = (tags) => {
 	// see types.jsonataTypeParser
@@ -42,7 +45,7 @@ export const renderProperty = (prop, index) => {
 		let defaultStr = renderDefaultTag(processDefaultTag(prop.tags));
 
 		return (
-			<section className={[css.property, (isDeprecated ? css.deprecated : null)].join(' ')} key={index} id={id}>
+			<Section className={[css.property, (isDeprecated ? css.deprecated : null)].join(' ')} key={index} id={id}>
 				<div className={css.title}>
 					<dt>
 						{prop.name} {requiredIcon} {deprecatedIcon}
@@ -57,7 +60,7 @@ export const renderProperty = (prop, index) => {
 						{defaultStr}
 					</div>
 				</dd>
-			</section>
+			</Section>
 		);
 	}
 };

--- a/src/utils/properties.js
+++ b/src/utils/properties.js
@@ -14,7 +14,7 @@ import {renderTypedefProp} from './typedefs.js';
 
 import css from '../css/main.module.less';
 
-const Section = (props) => FloatingAnchor.inline({component: 'section', ...props});
+const Dt = (props) => FloatingAnchor.inline({component: 'dt', ...props});
 
 const processTypeTag = (tags) => {
 	// see types.jsonataTypeParser
@@ -45,11 +45,11 @@ export const renderProperty = (prop, index) => {
 		let defaultStr = renderDefaultTag(processDefaultTag(prop.tags));
 
 		return (
-			<Section className={[css.property, (isDeprecated ? css.deprecated : null)].join(' ')} key={index} id={id}>
+			<section className={[css.property, (isDeprecated ? css.deprecated : null)].join(' ')} key={index} id={id}>
 				<div className={css.title}>
-					<dt>
+					<Dt id={id} inline>
 						{prop.name} {requiredIcon} {deprecatedIcon}
-					</dt>
+					</Dt>
 					<div className={css.types}>{renderPropertyTypeStrings(prop)}</div>
 				</div>
 				<dd className={css.description}>
@@ -60,7 +60,7 @@ export const renderProperty = (prop, index) => {
 						{defaultStr}
 					</div>
 				</dd>
-			</Section>
+			</section>
 		);
 	}
 };

--- a/src/utils/typedefs.js
+++ b/src/utils/typedefs.js
@@ -1,14 +1,17 @@
 // Utilities for working with typedefs. Used as part of /utils/modules.js
 
 import DocParse from '../components/DocParse.js';
+import FloatingAnchor from '../components/FloatingAnchor';
 import jsonata from 'jsonata';	// http://docs.jsonata.org/
 import React from 'react';
-import {renderDefaultTag, processDefaultTag, hasRequiredTag} from '../utils/common';
+import {renderDefaultTag, processDefaultTag} from '../utils/common';
 import renderFunction from './functions.js';
 import renderSeeTags from './see';
 import {renderType, jsonataTypeParser} from './types';
 
 import css from '../css/main.module.less';
+
+const Section = (props) => FloatingAnchor.inline({component: 'section', ...props});
 
 const renderTypedefTypeStrings = (member) => {
 	// see types.jsonataTypeParser
@@ -33,7 +36,7 @@ export const renderTypedefProp = (type, index) => {
 		let defaultStr = renderDefaultTag(processDefaultTag(type.tags));
 
 		return (
-			<section className={css.property} key={index} id={type.name}>
+			<Section className={css.property} key={index} id={type.name}>
 				<dt>
 					<div className={css.title} id={id}>{type.name} {isRequired}</div>
 				</dt>
@@ -45,7 +48,7 @@ export const renderTypedefProp = (type, index) => {
 					<DocParse component="div">{type.description}</DocParse>
 					{renderSeeTags(type)}
 				</dd>
-			</section>
+			</Section>
 		);
 	}
 };

--- a/src/utils/typedefs.js
+++ b/src/utils/typedefs.js
@@ -1,7 +1,6 @@
 // Utilities for working with typedefs. Used as part of /utils/modules.js
 
 import DocParse from '../components/DocParse.js';
-import FloatingAnchor from '../components/FloatingAnchor';
 import jsonata from 'jsonata';	// http://docs.jsonata.org/
 import React from 'react';
 import {renderDefaultTag, processDefaultTag} from '../utils/common';
@@ -10,8 +9,6 @@ import renderSeeTags from './see';
 import {renderType, jsonataTypeParser} from './types';
 
 import css from '../css/main.module.less';
-
-const Section = (props) => FloatingAnchor.inline({component: 'section', ...props});
 
 const renderTypedefTypeStrings = (member) => {
 	// see types.jsonataTypeParser
@@ -36,7 +33,7 @@ export const renderTypedefProp = (type, index) => {
 		let defaultStr = renderDefaultTag(processDefaultTag(type.tags));
 
 		return (
-			<Section className={css.property} key={index} id={type.name}>
+			<section className={css.property} key={index} id={type.name}>
 				<dt>
 					<div className={css.title} id={id}>{type.name} {isRequired}</div>
 				</dt>
@@ -48,7 +45,7 @@ export const renderTypedefProp = (type, index) => {
 					<DocParse component="div">{type.description}</DocParse>
 					{renderSeeTags(type)}
 				</dd>
-			</Section>
+			</section>
 		);
 	}
 };


### PR DESCRIPTION
### Feature Added
Adds `FloatingAnchor` component to allow deep linking to sections/methods/properties/typedefs

### Comments
* SVG and CSS approach were stolen/modeled from the [gatsby plugin](https://www.gatsbyjs.org/packages/gatsby-remark-autolink-headers/)
* `overflow: hidden` was removed to allow anchor to be visible since it floats to the left of the section. This change introduces collapsing margins but doesn't appear to adversely affect layout.