### PR TITLE
PLAT-61546: Add table of contents to static docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash": "^4.15.0",
     "markdown-it": "^8.4.0",
     "markdown-it-jsx": "^1.1.0",
+    "markdown-toc": "^1.2.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "postcss": "^5.2.17",

--- a/scripts/DocParser.js
+++ b/scripts/DocParser.js
@@ -126,13 +126,9 @@ function validate (docs, name, componentDirectory, strict) {
 }
 
 function parseTableOfContents (frontMatter, body) {
-	let maxdepth;
-	const tocConfig = frontMatter.match(/^toc: ?(false|\d+)$/m);
+	let maxdepth = 2;
+	const tocConfig = frontMatter.match(/^toc: ?(\d+)$/m);
 	if (tocConfig) {
-		if (tocConfig[1].toLowerCase() === 'false') {
-			return '';
-		}
-
 		maxdepth = Number.parseInt(tocConfig[1]);
 	}
 

--- a/scripts/DocParser.js
+++ b/scripts/DocParser.js
@@ -142,11 +142,11 @@ function parseTableOfContents (frontMatter, body) {
 	}
 
 	return `
-<div class="page-toc">
+<nav role="navigation" class="page-toc">
 
 ${table.content}
 
-</div>
+</nav>
 `;
 }
 


### PR DESCRIPTION
* Uses `markdown-toc` to parse the body and generate a table of contents
* Adds support for `toc` front matter property to configure depth or disabled table of contents

## Comments

Gatsby complains about `toc` supporting both `false` and numeric and warns that the field is omitted from GraphQL. If that's a concern for anyone, we can add another field to distinguish the too. As far as I can tell, it has no bearing on the output since the field isn't used outside of our parser.

Currently the table of contents is displayed inline in the content just below the top header. I've wrapped it with a `<nav>` with a class name so we could later style it in other ways.