### PR TITLE
ENYO-6321: "clean" script removes incorrect .less files

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -5,7 +5,7 @@ const leaveIndex = (dir, basePath = 'src/pages/docs/') => {
 	// remove everything but leave dir's index.js/index.less
 	const fullPath = basePath + dir;
 	const entries = shelljs.ls('-d', fullPath + '/*');
-	const matchIndex = new RegExp(`${fullPath}\/index\.(js|less)`);
+	const matchIndex = new RegExp(`${fullPath}\/index\.(js|module\.less)`);
 	entries.forEach(entry => {
 		if (!matchIndex.test(entry)) {
 			shelljs.rm('-r', entry);

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -5,7 +5,7 @@ const leaveIndex = (dir, basePath = 'src/pages/docs/') => {
 	// remove everything but leave dir's index.js/index.less
 	const fullPath = basePath + dir;
 	const entries = shelljs.ls('-d', fullPath + '/*');
-	const matchIndex = new RegExp(`${fullPath}\/index\.(js|module\.less)`);
+	const matchIndex = new RegExp(`${fullPath}\/index\.(js|(module\.)?less)`);
 	entries.forEach(entry => {
 		if (!matchIndex.test(entry)) {
 			shelljs.rm('-r', entry);


### PR DESCRIPTION
When running `npm run clean`, `src/pages/docs/modules/index.module.less` was being deleted and causing the app to not compile.

I updated the regexp match to leave it alone.