### PR TITLE
Add boolean literals and post-parse validation

### DIFF
--- a/scripts/DocParser.js
+++ b/scripts/DocParser.js
@@ -138,6 +138,7 @@ function validate (docs, path, componentDirectory, strict) {
 	const findSees = '**.*[tags[title="see"]] {"tags": [tags[title="see"]], "context": [context]}',
 		validSee = /({@link|http)/,
 		findLinks = "**[type='link'].url[]";
+		// TODO: findLinks with context: http://try.jsonata.org/BJv4E4UgL
 
 	if (docs.length > 1) {
 		const doclets = docs.map(docNameAndPosition).join('\n');

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -19,7 +19,7 @@ export const renderType = (type, index) => {
 export const jsonataTypeParser = `
 	$IsUnion := type = "UnionType";
 	$quote := function($val) { "'" & $val & "'" };
-	$GetNameExp := function($type) { $append($append($append($append($append($type[type="NameExpression"].name, $type[type="NullLiteral"] ? ['null'] : []), $type[type="AllLiteral"] ? ['Any'] : []), $map($type[type="StringLiteralType"].value, $quote)), $type[type="RecordType"] ? ['Object'] : []), $type[type="ArrayType"] ? ['Array'] : []) };
+	$GetNameExp := function($type) { $append($append($append($append($append($append($type[type="NameExpression"].name, $type[type="NullLiteral"] ? ['null'] : []), $type[type="AllLiteral"] ? ['Any'] : []), $map($type[type="StringLiteralType"].value, $quote)), $type[type="RecordType"] ? ['Object'] : []), $type[type="ArrayType"] ? ['Array'] : []), $type[type="BooleanLiteralType"].value.$string())};
 	$GetType := function($type) { $type[type="TypeApplication"] ? $type[type="TypeApplication"].(expression.name & " of " & $GetNameExp(applications)[0]) : $type[type="OptionalType"] ? $GetAllTypes($type.expression) : $type[type="RestType"] ? $GetAllTypes($type.expression)};
 	$GetAllTypes := function($elems) { $append($GetType($elems), $GetNameExp($elems))};
 	$IsUnion ? $GetAllTypes($.elements) : $GetAllTypes($);


### PR DESCRIPTION
This will correctly output boolean literals (`true`/`false`) in prop types.
Also, adds a post-processing step to validate that all `@mixes` and `@extends` are valid.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com