### PR TITLE
ENYO-6407: Clarify Repeater configuration in Kitten Browser tutorial

### DIFF
--- a/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
+++ b/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
@@ -30,7 +30,7 @@ In the [second step](../reusable-components/), we started breaking down our app 
 
 ## Repeaters and Lists
 
-A list is a basic building block for any application. Whether its a grid of images (as in our case), a newsfeed, a product catalog, or shopping cart, each can be implemented by a component that maps an array of data onto an array of component instances. The most basic version in Enact is the `Repeater`.
+A list is a basic building block for any application. Whether its a grid of images (as in our case), a newsfeed, a product catalog, or shopping cart, each can be implemented by a component that maps an array of data onto an array of component instances. The most basic version in Enact is the [Repeater](../../../modules/ui/Repeater/).
 
 ### Repeater
 
@@ -42,7 +42,7 @@ A list is a basic building block for any application. Whether its a grid of imag
 	{/* Array */}
 </Repeater>
 ```
-For Kitten Browser, `Kitten` will be the `childComponent` and we'll add an array of names as our data source, since our photos are random. We've also included an optional prop for Repeater, `indexProp`, which configures the property of `childComponent` that will receive the index of the data within the array.
+For Kitten Browser, `Kitten` will be the `childComponent` and we'll add an array of names as our data source, since our photos are random. We've also included an optional prop for Repeater, `indexProp`, which configures the property of `childComponent` that will receive the index of the data within the array. The default value of `indexProp` is `data-index`, so it would be added in the data attributes of the rendered DOM element. We're going to be computing a value for the image URL of a `Kitten` in the next section and that computed prop will use the `index` property as part of its value.
 
 Below are the updates to `./src/App/App.js`; the rest of the source has been omitted for brevity.
 ```js
@@ -109,6 +109,15 @@ computed: {
 	}
 },
 ```
+**Note**: We could do the same computation using the Repeater's default `indexProp` (`data-index`) by changing the destructuring to get the value out the Kitten's `data` attributes.
+```js
+computed: {
+	url: ({dataset: {index}, size}) => {
+		return `//loremflickr.com/${size}/${size}/kitten?random=${index}`;
+	}
+},
+```
+
 Finally, add `index` to the `propTypes`.
 ```js
 propTypes: {

--- a/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
+++ b/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
@@ -42,7 +42,7 @@ A list is a basic building block for any application. Whether its a grid of imag
 	{/* Array */}
 </Repeater>
 ```
-For Kitten Browser, `Kitten` will be the `childComponent` and we'll add an array of names as our data source, since our photos are random. We've also included an optional prop for Repeater, `indexProp`, which configures the property of `childComponent` that will receive the index of the data within the array. The default value of `indexProp` is `data-index`, so it would be added in the data attributes of the rendered DOM element. We're going to be computing a value for the image URL of a `Kitten` in the next section and that computed prop will use the `index` property as part of its value.
+For Kitten Browser, `Kitten` will be the `childComponent` and we'll add an array of names as our data source, since our photos are random. We've also included an optional prop for Repeater, `indexProp`, which configures the property of `childComponent` that will receive the index of the data within the array. The default value of `indexProp` is `data-index` and it would be available in the data attributes of the rendered DOM element. We're going to be computing a value for the image URL of a Kitten in the next section and that computed prop will use the `index` prop supplied by the Repeater as part of its value.
 
 Below are the updates to `./src/App/App.js`; the rest of the source has been omitted for brevity.
 ```js
@@ -109,7 +109,7 @@ computed: {
 	}
 },
 ```
-**Note**: We could do the same computation using the Repeater's default `indexProp` (`data-index`) by changing the destructuring to get the value out the Kitten's `data` attributes.
+**Note**: We could do the same computation using the Repeater's default `indexProp` (`data-index`) by changing the destructuring to get the value out of the Kitten instance's data attributes (DOM attributes prepended with `data-`) instead. Component props will include all DOM data attributes as `dataset`, so the value of the DOM attribute `data-index` would be found in `props.dataset.index` and `data-foo`'s value would be in `props.dataset.foo`.
 ```js
 computed: {
 	url: ({dataset: {index}, size}) => {

--- a/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
+++ b/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
@@ -109,10 +109,10 @@ computed: {
 	}
 },
 ```
-**Note**: We could do the same computation using the Repeater's default `indexProp` (`data-index`) by changing the destructuring to get the value out of the Kitten instance's data attributes (DOM attributes prepended with `data-`) instead. Component props will include all DOM data attributes as `dataset`, so the value of the DOM attribute `data-index` would be found in `props.dataset.index` and `data-foo`'s value would be in `props.dataset.foo`.
+**Note**: We could do the same computation using the Repeater's default `indexProp` (`data-index`) by changing the destructuring to get the value out of the Kitten instance's data attributes (DOM attributes prepended with `data-`) instead.  Since the key name contains a hyphen (`-`) it will need to be quoted.
 ```js
 computed: {
-	url: ({dataset: {index}, size}) => {
+	url: ({'data-index': index, size}) => {
 		return `//loremflickr.com/${size}/${size}/kitten?random=${index}`;
 	}
 },


### PR DESCRIPTION
* Link added for `Repeater` docs
* Detail added for why `indexProp` is being set to `index` instead of the default
* Example code added for using the default value (`data-index`) for the curious