### PR TITLE
ENYO-6424: Update Enact Development Setup tutorial to correct webOS app setup

### DIFF
--- a/src/pages/docs/tutorials/setup/index.md
+++ b/src/pages/docs/tutorials/setup/index.md
@@ -29,6 +29,7 @@ The first command you'll use is `enact create [<directory>]` to create a new app
 > ```bash
 > enact template install @enact/template-webostv
 > enact create -t webostv [<directory>]
+> 
 > ```
 
 ### Directory Structure

--- a/src/pages/docs/tutorials/setup/index.md
+++ b/src/pages/docs/tutorials/setup/index.md
@@ -25,7 +25,11 @@ Once installed, you can run `enact` from anywhere to run a command.
 
 The first command you'll use is `enact create [<directory>]` to create a new application. The `[<directory>]` argument is optional and defaults to the current working directory. `create` creates the [initial directory structure](#directory-structure) and [configures the app](#configuring-the-application).
 
-> **Note**: If you are developing an app for a webOS-based system (webOS TVs, [webOS OSE](https://www.webosose.org/), etc.) you can use the `webostv` template to create your application: `enact create -t webostv [<directory>]`
+> **Note**: If you are developing an app for a webOS-based system (webOS TVs, [webOS OSE](https://www.webosose.org/), etc.) you can use the [`webostv`](https://www.npmjs.com/package/@enact/template-webostv) template to create your application:
+> ```bash
+> enact template install @enact/template-webostv
+> enact create -t webostv [<directory>]
+> ```
 
 ### Directory Structure
 

--- a/src/pages/docs/tutorials/setup/index.md
+++ b/src/pages/docs/tutorials/setup/index.md
@@ -25,16 +25,18 @@ Once installed, you can run `enact` from anywhere to run a command.
 
 The first command you'll use is `enact create [<directory>]` to create a new application. The `[<directory>]` argument is optional and defaults to the current working directory. `create` creates the [initial directory structure](#directory-structure) and [configures the app](#configuring-the-application).
 
+> **Note**: If you are developing an app for a webOS-based system (webOS TVs, [webOS OSE](https://www.webosose.org/), etc.) you can use the `webostv` template to create your application: `enact create -t webostv [<directory>]`
+
 ### Directory Structure
 
 The application directory includes:
 
 * `README.md` containing some useful tips on creating and building your application,
-* `package.json`, a file describing the application,
-* a `node_modules` directory containing all of your external dependencies (such as `@enact/core` and `react`),
-* a `resources` directory containing localization files,
-* a `src` directory containing all your source files, both JS and CSS/LESS, and
-* a `webos-meta` directory containing files necessary for webOS deployment.
+* `package.json`, a file describing the application
+* a `node_modules` directory containing all of your external dependencies (such as `@enact/core` and `react`)
+* a `resources` directory containing localization files
+* a `src` directory containing all your source files, both JS and CSS/LESS
+* optionally, a `webos-meta` directory containing files necessary for webOS deployment
 
 When you package your app, it will be placed into a `dist` directory.  You won't see this yet, but know that it's coming.
 
@@ -56,7 +58,7 @@ App
 │   └── views
 │       ├── MainPanel.js
 │       └── README.md
-└── webos-meta
+└── webos-meta (present if the `webostv` template was used to create the app)
 	├── appinfo.json
 	├── icon-large.png
 	├── icon-mini.png
@@ -84,14 +86,16 @@ Your application is configured using the `package.json` file. We'll only cover t
 	"private": true,
 	"repository": "",
 	"enact": {
-		"isomorphic": "src/iso.js",
-		"ri": {
-			"baseSize": 24
-		}
+		"theme": "moonstone"
 	},
 	"eslintConfig": {
 		"extends": "enact"
 	},
+	"eslintIgnore": [
+		"node_modules/*",
+		"build/*",
+		"dist/*"
+	],
 	"dependencies": { [omitted] }
 }
 ```

--- a/src/pages/docs/tutorials/setup/index.md
+++ b/src/pages/docs/tutorials/setup/index.md
@@ -26,10 +26,10 @@ Once installed, you can run `enact` from anywhere to run a command.
 The first command you'll use is `enact create [<directory>]` to create a new application. The `[<directory>]` argument is optional and defaults to the current working directory. `create` creates the [initial directory structure](#directory-structure) and [configures the app](#configuring-the-application).
 
 > **Note**: If you are developing an app for a webOS-based system (webOS TVs, [webOS OSE](https://www.webosose.org/), etc.) you can use the [`webostv`](https://www.npmjs.com/package/@enact/template-webostv) template to create your application:
+> 
 > ```bash
 > enact template install @enact/template-webostv
 > enact create -t webostv [<directory>]
-> 
 > ```
 
 ### Directory Structure

--- a/src/pages/docs/tutorials/tutorial-hello-enact/adding-moonstone-support/index.md
+++ b/src/pages/docs/tutorials/tutorial-hello-enact/adding-moonstone-support/index.md
@@ -89,7 +89,7 @@ const App = MoonstoneDecorator(AppBase);
 export default App;
 export {App, AppBase};
 ```
-> **Note:** We've renamed the stateless component from `App` to `AppBase`. The
+> **Note**: We've renamed the stateless component from `App` to `AppBase`. The
 > Enact framework uses this convention to distinguish between stateless components and their wrapped or stateful versions.
 > If you need to use the stateless version of a component, it will be exported as a named export with
 > `Base` appended to the name.

--- a/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
+++ b/src/pages/docs/tutorials/tutorial-kitten-browser/lists/index.md
@@ -107,16 +107,16 @@ computed: {
 	url: ({index, size}) => {
 		return `//loremflickr.com/${size}/${size}/kitten?random=${index}`;
 	}
-},
+}
 ```
-**Note**: We could do the same computation using the Repeater's default `indexProp` (`data-index`) by changing the destructuring to get the value out of the Kitten instance's data attributes (DOM attributes prepended with `data-`) instead.  Since the key name contains a hyphen (`-`) it will need to be quoted.
-```js
-computed: {
-	url: ({'data-index': index, size}) => {
-		return `//loremflickr.com/${size}/${size}/kitten?random=${index}`;
-	}
-},
-```
+> **Note**: We could do the same computation using the Repeater's default `indexProp` (`data-index`) by changing the destructuring to get the value out of the Kitten instance's data attributes (DOM attributes prepended with `data-`) instead.  Since the key name contains a hyphen (`-`) it will need to be quoted.
+> ```js
+> computed: {
+> 	url: ({'data-index': index, size}) => {
+> 		return `//loremflickr.com/${size}/${size}/kitten?random=${index}`;
+> 	}
+> }
+> ```
 
 Finally, add `index` to the `propTypes`.
 ```js

--- a/src/pages/docs/tutorials/tutorial-typescript/app-setup/index.md
+++ b/src/pages/docs/tutorials/tutorial-typescript/app-setup/index.md
@@ -14,7 +14,7 @@ The Enact CLI provides a template ([@enact/template-typescript](https://www.npmj
 
 ### Installing the TypeScript Template
 
-> NOTE: Before you begin this tutorial, make sure you have installed the Enact CLI tool.  See [Enact Development Setup](../../setup/) for more information.
+> **Note**: Before you begin this tutorial, make sure you have installed the Enact CLI tool.  See [Enact Development Setup](../../setup/) for more information.
 
 - Install the TypeScript template
 

--- a/src/pages/docs/tutorials/tutorial-typescript/component-with-ts-enact/index.md
+++ b/src/pages/docs/tutorials/tutorial-typescript/component-with-ts-enact/index.md
@@ -87,7 +87,7 @@ const CounterBase = kind<Props>({
 export default CounterBase;
 ```
 
-> Note: We've left the event handlers optional so we don't have to update **App.js** and we'll be replacing them in the next section.
+> **Note**: We've left the event handlers optional so we don't have to update **App.js** and we'll be replacing them in the next section.
 
 ### Counter View in the Browser
 
@@ -159,9 +159,9 @@ const Counter = Changeable({prop: 'count' , change: 'onCounterChange'}, CounterB
 export default Counter;
 ```
 
-> Note: The `createHandler` function is simply a shortcut to allow us to avoid duplicating the same piece of code three times (once for each of the events we need to handle). What the code does is take a function that modifies the `count` value and returns the new value. It takes the incoming click event and then creates a new event to pass to the `onCounterChange` event from `Changeable`, passing it the value modified by the function.
+> **Note**: The `createHandler` function is simply a shortcut to allow us to avoid duplicating the same piece of code three times (once for each of the events we need to handle). What the code does is take a function that modifies the `count` value and returns the new value. It takes the incoming click event and then creates a new event to pass to the `onCounterChange` event from `Changeable`, passing it the value modified by the function.
 
-> Note: Because the `onCounterChange` event is being supplied by `Changeable`, we'll mark it as optional since we don't want it to be required from its parent.
+> **Note**: Because the `onCounterChange` event is being supplied by `Changeable`, we'll mark it as optional since we don't want it to be required from its parent.
 
 ### Counter View in the Browser
 


### PR DESCRIPTION
A couple of minor doc updates:

- updates the setup portion to reflect accurate `webos-meta` directory information
- uses same convention for **Note**s across the tutorials