### PR TITLE
PLAT-104269: Rename AgateDecorator to ThemeDecorator

### DIFF
--- a/sample-runner/agate/src/EnactImporter.js
+++ b/sample-runner/agate/src/EnactImporter.js
@@ -2,7 +2,6 @@
 import kind from '@enact/core/kind';
 
 // Agate
-import AgateDecorator from '@enact/agate/AgateDecorator'
 import Button from '@enact/agate/Button';
 import Checkbox from '@enact/agate/Checkbox';
 import CheckboxItem from '@enact/agate/CheckboxItem';
@@ -32,6 +31,7 @@ import SliderButton from '@enact/agate/SliderButton';
 import Spinner from '@enact/agate/Spinner';
 import Switch from '@enact/agate/Switch';
 import SwitchItem from '@enact/agate/SwitchItem';
+import ThemeDecorator from '@enact/agate/ThemeDecorator'
 import ThumbnailItem from '@enact/agate/ThumbnailItem';
 import ToggleButton from '@enact/agate/ToggleButton';
 import VirtualList, {VirtualGridList} from '@enact/agate/VirtualList';
@@ -50,7 +50,6 @@ const enactExports = {
 };
 
 const agateExports = {
-	AgateDecorator,
 	Button,
 	Checkbox,
 	CheckboxItem,
@@ -80,6 +79,7 @@ const agateExports = {
 	Spinner,
 	Switch,
 	SwitchItem,
+	ThemeDecorator,
 	ThumbnailItem,
 	ToggleButton,
 	VirtualList,
@@ -107,4 +107,4 @@ const exports = {
 };
 
 export default exports;
-export {AgateDecorator as ThemeDecorator};
+export {ThemeDecorator};

--- a/sample-runner/sandstone/src/EnactImporter.js
+++ b/sample-runner/sandstone/src/EnactImporter.js
@@ -25,7 +25,6 @@ import LabeledIcon from '@enact/sandstone/LabeledIcon';
 import LabeledIconButton from '@enact/sandstone/LabeledIconButton';
 import Marquee from '@enact/sandstone/Marquee';
 import MediaOverlay from '@enact/sandstone/MediaOverlay';
-import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 import Panels, {Header} from '@enact/sandstone/Panels';
 import Picker from '@enact/sandstone/Picker';
 import Popup from '@enact/sandstone/Popup';
@@ -39,6 +38,7 @@ import Spinner from '@enact/sandstone/Spinner';
 import Steps from '@enact/sandstone/Steps';
 import Switch from '@enact/sandstone/Switch';
 import SwitchItem from '@enact/sandstone/SwitchItem';
+import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 import TimePicker from '@enact/sandstone/TimePicker';
 import TooltipDecorator from '@enact/sandstone/TooltipDecorator';
 import VideoPlayer from '@enact/sandstone/VideoPlayer';
@@ -101,7 +101,6 @@ const sandstoneExports = {
 	LabeledIconButton,
 	Marquee,
 	MediaOverlay,
-	ThemeDecorator,
 	Panels,
 	Picker,
 	Popup,
@@ -115,6 +114,7 @@ const sandstoneExports = {
 	Steps,
 	Switch,
 	SwitchItem,
+	ThemeDecorator,
 	TimePicker,
 	TooltipDecorator,
 	VideoPlayer,


### PR DESCRIPTION
This patch updates the `agate` sample runner to use `ThemeDecorator` and re-sorts the replacement of `MoonstoneDecorator` to `ThemeDecorator` for `sandstone` sample-runner