### PR TITLE
PLAT-107337: Render better return types

### DIFF
--- a/src/components/SmartLink/SmartLink.js
+++ b/src/components/SmartLink/SmartLink.js
@@ -5,16 +5,17 @@ import {Link} from 'gatsby';
 import {OutboundLink} from 'gatsby-plugin-google-analytics';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {useLocation} from '@reach/router'
+import {useLocation} from '@reach/router';
 
+// eslint-disable-next-line enact/prop-types
 function LocationLink ({to, ...rest}) {
 	const parts = to.split('#');
 	const location = useLocation();
 
 	if (parts.length > 1 && parts[0] === location.pathname) {
-		return <a {...rest} href={`#${parts[1]}`} />
+		return <a {...rest} href={`#${parts[1]}`} />;
 	}
-	return <Link to={to} {...rest} />
+	return <Link to={to} {...rest} />;
 }
 
 // Takes either a jsdoc `{@link}` or it takes a module name of the form `package/module.member` as

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -18,7 +18,7 @@ export const renderType = (type, index) => {
 // NOTE: This is shared with a few parsers that have slightly
 // different selectors
 export const jsonataTypeParser = `
-	$IsUnion := type = "UnionType";
+	$IsRootNullable := type = "NullableType";
 	$quote := function($val) { "'" & $val & "'" };
 	$GetNameExp := function($type) {
 		[
@@ -35,7 +35,8 @@ export const jsonataTypeParser = `
 	};
 	$GetType := function($type) { $type[type="TypeApplication"] ? $type[type="TypeApplication"].(expression.name & " of " & $GetNameExp(applications)[0]) : $type[type="OptionalType"] ? $GetAllTypes($type.expression) : $type[type="RestType"] ? $GetAllTypes($type.expression)};
 	$GetAllTypes := function($elems) { $append($GetType($elems), $GetNameExp($elems))};
-	$IsUnion ? $GetAllTypes($.elements) : $GetAllTypes($);
+	$CheckUnionTypes := function($elem) { $elem.type = "UnionType" ? $GetAllTypes($elem.elements) : $GetAllTypes($elem) };
+	$IsRootNullable ? $CheckUnionTypes($.expression) : $CheckUnionTypes($);
 `;
 
 export default renderType;

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -14,6 +14,7 @@ export const renderType = (type, index) => {
 // 'AllLiteral' and replaces them with the word 'null' or 'Any'. If any 'StringLiteralType'
 // exist, add them with quotes around the value. A 'RecordType' is replaced with 'Object'.
 // TODO: Add NumberLiteralType?
+// TODO: Make NullableType more useful/interesting?
 // NOTE: This is shared with a few parsers that have slightly
 // different selectors
 export const jsonataTypeParser = `
@@ -21,14 +22,15 @@ export const jsonataTypeParser = `
 	$quote := function($val) { "'" & $val & "'" };
 	$GetNameExp := function($type) {
 		[
-			$type[type="NameExpression"].name,
-			$type[type="NullLiteral"] ? ['null'],
-			$type[type="UndefinedLiteral"] ? ['undefined'],
 			$type[type="AllLiteral"] ? ['Any'],
-			$map($type[type="StringLiteralType"].value, $quote),
-			$type[type="RecordType"] ? ['Object'],
 			$type[type="ArrayType"] ? ['Array'],
-			$type[type="BooleanLiteralType"].value.$string()
+			$type[type="BooleanLiteralType"].value.$string(),
+			$type[type="NameExpression"].name,
+			$map($type[type="NullableType"].expression, $GetNameExp),
+			$type[type="NullLiteral"] ? ['null'],
+			$type[type="RecordType"] ? ['Object'],
+			$map($type[type="StringLiteralType"].value, $quote),
+			$type[type="UndefinedLiteral"] ? ['undefined']
 		]
 	};
 	$GetType := function($type) { $type[type="TypeApplication"] ? $type[type="TypeApplication"].(expression.name & " of " & $GetNameExp(applications)[0]) : $type[type="OptionalType"] ? $GetAllTypes($type.expression) : $type[type="RestType"] ? $GetAllTypes($type.expression)};

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -19,7 +19,18 @@ export const renderType = (type, index) => {
 export const jsonataTypeParser = `
 	$IsUnion := type = "UnionType";
 	$quote := function($val) { "'" & $val & "'" };
-	$GetNameExp := function($type) { $append($append($append($append($append($append($append($type[type="NameExpression"].name, $type[type="NullLiteral"] ? ['null'] : []), $type[type="UndefinedLiteral"] ? ['undefined'] : []), $type[type="AllLiteral"] ? ['Any'] : []), $map($type[type="StringLiteralType"].value, $quote)), $type[type="RecordType"] ? ['Object'] : []), $type[type="ArrayType"] ? ['Array'] : []), $type[type="BooleanLiteralType"].value.$string())};
+	$GetNameExp := function($type) {
+		[
+			$type[type="NameExpression"].name,
+			$type[type="NullLiteral"] ? ['null'],
+			$type[type="UndefinedLiteral"] ? ['undefined'],
+			$type[type="AllLiteral"] ? ['Any'],
+			$map($type[type="StringLiteralType"].value, $quote),
+			$type[type="RecordType"] ? ['Object'],
+			$type[type="ArrayType"] ? ['Array'],
+			$type[type="BooleanLiteralType"].value.$string()
+		]
+	};
 	$GetType := function($type) { $type[type="TypeApplication"] ? $type[type="TypeApplication"].(expression.name & " of " & $GetNameExp(applications)[0]) : $type[type="OptionalType"] ? $GetAllTypes($type.expression) : $type[type="RestType"] ? $GetAllTypes($type.expression)};
 	$GetAllTypes := function($elems) { $append($GetType($elems), $GetNameExp($elems))};
 	$IsUnion ? $GetAllTypes($.elements) : $GetAllTypes($);

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -27,15 +27,15 @@ export const jsonataTypeParser = `
 			$type[type="ArrayType"] ? ['Array'],
 			$type[type="BooleanLiteralType"].value.$string(),
 			$type[type="NameExpression"].name,
-			$map($type[type="NullableType"].expression, $GetNameExp),
-            $map($type[type="UnionType"], $GetElementsTypes),
+			$type[type="NullableType"] ? [$GetNameExp($type[type="NullableType"].expression), 'null'],
 			$type[type="NullLiteral"] ? ['null'],
 			$map($type[type="OptionalType"], $GetExpressionTypes),
 			$type[type="RecordType"] ? ['Object'],
 			$map($type[type="RestType"], $GetExpressionTypes),
 			$map($type[type="StringLiteralType"].value, $quote),
 			$map($type[type="TypeApplication"], $ProcessTypeApplication),
-			$type[type="UndefinedLiteral"] ? ['undefined']
+			$type[type="UndefinedLiteral"] ? ['undefined'],
+			$map($type[type="UnionType"], $GetElementsTypes)
 		]
 	};
 	$GetNameExp($);

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -19,7 +19,7 @@ export const renderType = (type, index) => {
 export const jsonataTypeParser = `
 	$IsUnion := type = "UnionType";
 	$quote := function($val) { "'" & $val & "'" };
-	$GetNameExp := function($type) { $append($append($append($append($append($append($type[type="NameExpression"].name, $type[type="NullLiteral"] ? ['null'] : []), $type[type="AllLiteral"] ? ['Any'] : []), $map($type[type="StringLiteralType"].value, $quote)), $type[type="RecordType"] ? ['Object'] : []), $type[type="ArrayType"] ? ['Array'] : []), $type[type="BooleanLiteralType"].value.$string())};
+	$GetNameExp := function($type) { $append($append($append($append($append($append($append($type[type="NameExpression"].name, $type[type="NullLiteral"] ? ['null'] : []), $type[type="UndefinedLiteral"] ? ['undefined'] : []), $type[type="AllLiteral"] ? ['Any'] : []), $map($type[type="StringLiteralType"].value, $quote)), $type[type="RecordType"] ? ['Object'] : []), $type[type="ArrayType"] ? ['Array'] : []), $type[type="BooleanLiteralType"].value.$string())};
 	$GetType := function($type) { $type[type="TypeApplication"] ? $type[type="TypeApplication"].(expression.name & " of " & $GetNameExp(applications)[0]) : $type[type="OptionalType"] ? $GetAllTypes($type.expression) : $type[type="RestType"] ? $GetAllTypes($type.expression)};
 	$GetAllTypes := function($elems) { $append($GetType($elems), $GetNameExp($elems))};
 	$IsUnion ? $GetAllTypes($.elements) : $GetAllTypes($);


### PR DESCRIPTION
`resolution` wasn't showing return types for certain functions.  This aligns return types with parameters and adds support for `UndefinedLiteral`.

Enact-DCO-1.0-Signed-off-by: Roy Sutton roy.sutton@lge.com