### PR TITLE
PLAT-113675 Fix usage of Slottable

### DIFF
--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -189,7 +189,7 @@ const Page = Toggleable(
 	ScrollDetector(
 		Slottable(
 			{
-				slots: 'sidebar'
+				slots: ['sidebar']
 			},
 			PageBase
 		)


### PR DESCRIPTION
The `Page` component was incorrectly passing a string instead of an array of strings to `Slottable`.  This mostly (sorta) worked with previous versions of Enact.  With `3.3.0`, this now throws an error.