### PR TITLE
WRO-7413: Remove using svg background image in css file

### DIFF
--- a/src/components/SiteHeader/SiteHeader.js
+++ b/src/components/SiteHeader/SiteHeader.js
@@ -10,6 +10,7 @@ import {linkIsLocation, linkIsBaseOf} from '../../utils/paths.js';
 import Search from '../Search';
 
 import css from './SiteHeader.module.less';
+import logo from '../../assets/enact.svg';
 
 const SiteHeaderBase = kind({
 	name: 'SiteHeader',
@@ -43,10 +44,10 @@ const SiteHeaderBase = kind({
 				<SiteSection className={css.frame}>
 					<Row className={css.container} align="center">
 						<Cell className={css.siteTitle} shrink>
-							<Link to="/" className={css.logo}>
-								<span className={css.image} />
+						<Link to="/" className={css.logo}>
+								<img alt="enact logo" src={logo} className={css.image} />
 								<span className={css.text}>{title}</span>
-							</Link>
+						</Link>
 						</Cell>
 						<Cell>
 							<div className={css.siteSearch}>

--- a/src/components/SiteHeader/SiteHeader.js
+++ b/src/components/SiteHeader/SiteHeader.js
@@ -44,10 +44,10 @@ const SiteHeaderBase = kind({
 				<SiteSection className={css.frame}>
 					<Row className={css.container} align="center">
 						<Cell className={css.siteTitle} shrink>
-						<Link to="/" className={css.logo}>
+							<Link to="/" className={css.logo}>
 								<img alt="enact logo" src={logo} className={css.image} />
 								<span className={css.text}>{title}</span>
-						</Link>
+							</Link>
 						</Cell>
 						<Cell>
 							<div className={css.siteSearch}>

--- a/src/components/SiteHeader/SiteHeader.module.less
+++ b/src/components/SiteHeader/SiteHeader.module.less
@@ -92,7 +92,8 @@
 
 			.image {
 				display: inline-block;
-				background: @docs-header-logo-color url(../../assets/enact.svg) no-repeat;
+				background-color: @docs-header-logo-color;
+				background-repeat: no-repeat;
 				background-size: contain;
 				height: @docs-header-logo-image-size;
 				width: @docs-header-logo-image-size;

--- a/src/components/SiteHeader/SiteHeader.module.less
+++ b/src/components/SiteHeader/SiteHeader.module.less
@@ -93,8 +93,6 @@
 			.image {
 				display: inline-block;
 				background-color: @docs-header-logo-color;
-				background-repeat: no-repeat;
-				background-size: contain;
 				height: @docs-header-logo-image-size;
 				width: @docs-header-logo-image-size;
 				position: absolute;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
'.svg' file in css is broken in 'gatsby build' process
(https://github.com/gatsbyjs/gatsby/issues/34395)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Because it is a gatsby problem, it cannot be fundamentally fixed, so I removed svg from the css file and changed it to import and use svg from js file

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-7413

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)
