### PR TITLE
WRO-13490: Fix parseLink() from DocParse

### DIFF
--- a/src/components/DocParse.js
+++ b/src/components/DocParse.js
@@ -11,7 +11,7 @@ function parseCodeBlock (child, index) {
 }
 
 function parseLink (child, index) {
-	let title = child.url;
+	let title = child.url || child.children[0].value;
 	const linkText = child.children[0].value || linkReference || title;
 	const url = child.url;
 

--- a/src/components/DocParse.js
+++ b/src/components/DocParse.js
@@ -11,8 +11,8 @@ function parseCodeBlock (child, index) {
 }
 
 function parseLink (child, index) {
-	let title = child.children[0].value;
-	const linkText = child.children[0].text || linkReference || title;
+	let title = child.url;
+	const linkText = child.children[0].value || linkReference || title;
 	const url = child.url;
 
 	if (url && url.indexOf('http') === 0) {


### PR DESCRIPTION
Fixed parseLink() function to not show 404 error