### PR TITLE
WRO-672: Update eslintConfig in sample-runner to use the root's eslint-config-enact-proxy

### DIFF
--- a/sample-runner/agate/package.json
+++ b/sample-runner/agate/package.json
@@ -21,9 +21,6 @@
   "enact": {
     "theme": "agate"
   },
-  "eslintConfig": {
-    "extends": "enact-proxy/strict"
-  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",
@@ -40,8 +37,5 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
-  },
-  "devDependencies": {
-    "eslint-config-enact-proxy": "^1.0.0"
   }
 }

--- a/sample-runner/agate/package.json
+++ b/sample-runner/agate/package.json
@@ -22,7 +22,7 @@
     "theme": "agate"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy/strict"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -40,5 +40,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.0"
   }
 }

--- a/sample-runner/agate/package.json
+++ b/sample-runner/agate/package.json
@@ -21,6 +21,9 @@
   "enact": {
     "theme": "agate"
   },
+  "eslintConfig": {
+    "extends": "enact-proxy"
+  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",

--- a/sample-runner/core/package.json
+++ b/sample-runner/core/package.json
@@ -18,6 +18,9 @@
   "license": "Apache-2.0",
   "private": true,
   "repository": "",
+  "eslintConfig": {
+    "extends": "enact-proxy"
+  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",

--- a/sample-runner/core/package.json
+++ b/sample-runner/core/package.json
@@ -19,7 +19,7 @@
   "private": true,
   "repository": "",
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy/strict"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -36,5 +36,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.0"
   }
 }

--- a/sample-runner/core/package.json
+++ b/sample-runner/core/package.json
@@ -18,9 +18,6 @@
   "license": "Apache-2.0",
   "private": true,
   "repository": "",
-  "eslintConfig": {
-    "extends": "enact-proxy/strict"
-  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",
@@ -36,8 +33,5 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
-  },
-  "devDependencies": {
-    "eslint-config-enact-proxy": "^1.0.0"
   }
 }

--- a/sample-runner/moonstone/package.json
+++ b/sample-runner/moonstone/package.json
@@ -21,9 +21,6 @@
   "enact": {
     "theme": "moonstone"
   },
-  "eslintConfig": {
-    "extends": "enact-proxy/strict"
-  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",
@@ -40,8 +37,5 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
-  },
-  "devDependencies": {
-    "eslint-config-enact-proxy": "^1.0.0"
   }
 }

--- a/sample-runner/moonstone/package.json
+++ b/sample-runner/moonstone/package.json
@@ -22,7 +22,7 @@
     "theme": "moonstone"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy/strict"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -40,5 +40,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.0"
   }
 }

--- a/sample-runner/moonstone/package.json
+++ b/sample-runner/moonstone/package.json
@@ -21,6 +21,9 @@
   "enact": {
     "theme": "moonstone"
   },
+  "eslintConfig": {
+    "extends": "enact-proxy"
+  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",

--- a/sample-runner/sandstone/package.json
+++ b/sample-runner/sandstone/package.json
@@ -21,6 +21,9 @@
   "enact": {
     "theme": "sandstone"
   },
+  "eslintConfig": {
+    "extends": "enact-proxy"
+  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",

--- a/sample-runner/sandstone/package.json
+++ b/sample-runner/sandstone/package.json
@@ -22,7 +22,7 @@
     "theme": "sandstone"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy/strict"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -40,5 +40,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.0"
   }
 }

--- a/sample-runner/sandstone/package.json
+++ b/sample-runner/sandstone/package.json
@@ -21,9 +21,6 @@
   "enact": {
     "theme": "sandstone"
   },
-  "eslintConfig": {
-    "extends": "enact-proxy/strict"
-  },
   "eslintIgnore": [
     "node_modules/*",
     "build/*",
@@ -40,8 +37,5 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-live": "^1.11.0"
-  },
-  "devDependencies": {
-    "eslint-config-enact-proxy": "^1.0.0"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
To use eslint-config-enact-proxy, we need to update eslintConfig.
This allows the docs repo to support in-editor linting, too.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update eslintConfig in sample-runner to use the root's eslint-config-enact-proxy.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
NOTE:

For docs, in-editor lighting may not work.
This is because the `gatsby` module installed in docs contains eslint, which conflicts with eslint installed in npmGlobal.
For in-editor linting to function normally, you need to modify the setting extension:eslint in vscode.

HOWTO: 
On Windows/Linux - File > Preferences > Settings
On macOS - Code > Preferences > Settings
→ Go to Settings, click(Open settings(JSON)) in the upper right corner

> "eslint.nodePath": "myCustomNodePath" // Write the directory of npmGlobal


※ the direction of npmGlobal: input `npm root -g` in your terminal

### Links
[//]: # (Related issues, references)
WRO-672

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)