### PR TITLE
WRP-2861: Add a menu linking to enactjs.com/sampler

### DIFF
--- a/src/components/SiteHeader/SiteHeader.js
+++ b/src/components/SiteHeader/SiteHeader.js
@@ -86,6 +86,13 @@ const SiteHeaderBase = kind({
 								>
 									Github
 								</Cell>
+								<Cell
+									component={OutboundLink}
+									shrink
+									href="https://enactjs.com/sampler"
+								>
+									Sampler
+								</Cell>
 							</Row>
 						</Cell>
 					</Row>

--- a/src/components/SiteHeader/SiteHeader.js
+++ b/src/components/SiteHeader/SiteHeader.js
@@ -91,7 +91,7 @@ const SiteHeaderBase = kind({
 									shrink
 									href="https://enactjs.com/sampler"
 								>
-									Sampler
+									UI Components
 								</Cell>
 							</Row>
 						</Cell>


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)

Currently. there is no menu on enactjs.com to view the sampler.
People who do not know the entire url (enactjs.com/sampler) cannot access it.
So add 'SAMPLER' menu.