### PR TITLE
Update .travis.yml to change the CLI downloading method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ node_js:
 sudo: false
 install:
     - npm config set prefer-offline false
-    - npm install -g enactjs/cli#develop
+    - git clone --branch=develop --depth 1 https://github.com/enactjs/cli ../cli
+    - pushd ../cli
+    - npm install
+    - npm link
+    - popd
     - npm install --legacy-peer-deps
 script:
     - echo -e "\x1b\x5b35;1m*** Linting docs...\x1b\x5b0m"


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
There is a difference between 'npm install gitbranch' and 'git clone gitbranch' -> 'npm install'.
Need to use the git clone method to follow the already tested npm-shrinkwrap.json during travis build.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update .travis.yml to download the cli source code with git clone and then run 'npm install' and 'npm link' in the cli directory. 

### Links
[//]: # (Related issues, references)
WRP-9221

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)