### PR TITLE
WRP-10246: Component example cut off in docs

### DIFF
--- a/sample-runner/shared/EnactLiveEdit.module.less
+++ b/sample-runner/shared/EnactLiveEdit.module.less
@@ -16,13 +16,13 @@
 
 .sandbox {
 	overflow: hidden;
-	padding-bottom: 50px;
+	padding-bottom: 51px;
 	position: relative;
 	width: 100%;
 }
 
 .reactLivePreview {
 	min-height: 99px;
-	padding-left: 20px;
-	padding-top: 4px;
+	padding-left: 36px;
+	padding-top: 36px;
 }

--- a/sample-runner/shared/EnactLiveEdit.module.less
+++ b/sample-runner/shared/EnactLiveEdit.module.less
@@ -16,11 +16,13 @@
 
 .sandbox {
 	overflow: hidden;
+	padding-bottom: 50px;
 	position: relative;
 	width: 100%;
 }
 
 .reactLivePreview {
-	padding-top: 4px;
 	min-height: 99px;
+	padding-left: 20px;
+	padding-top: 4px;
 }

--- a/src/components/EnactLiveEdit.js
+++ b/src/components/EnactLiveEdit.js
@@ -73,7 +73,8 @@ export default class EnactLiveEdit extends Component {
 	render () {
 		if (this.state.ready) {
 			const theme = getThemeName(this.props.name);
-			const dropdown = this.props.code.includes('Dropdown') ? css.dropdown : '';
+			const dropdownClass = theme === 'agate' ? css.dropdownAgate : css.dropdownSandstoneMoonstone;
+			const dropdown = this.props.code.includes('Dropdown') ? dropdownClass : '';
 			return (
 				// eslint-disable-next-line jsx-a11y/iframe-has-title
 				<iframe

--- a/src/components/EnactLiveEdit.js
+++ b/src/components/EnactLiveEdit.js
@@ -73,10 +73,11 @@ export default class EnactLiveEdit extends Component {
 	render () {
 		if (this.state.ready) {
 			const theme = getThemeName(this.props.name);
+			const dropdown = this.props.code.includes('Dropdown') ? css.dropdown : '';
 			return (
 				// eslint-disable-next-line jsx-a11y/iframe-has-title
 				<iframe
-					className={css.frame}
+					className={`${css.frame} ${dropdown}`}
 					ref={this.setFrame}
 					src={withPrefix(`/${theme}-runner/index.html`)}
 				/>

--- a/src/components/EnactLiveEdit.module.less
+++ b/src/components/EnactLiveEdit.module.less
@@ -1,7 +1,12 @@
 // EnactLiveEdit.less
 //
 
-.dropdown {
+.dropdownAgate {
+	background-color: white;
+	height: 530px;
+}
+
+.dropdownSandstoneMoonstone {
 	background-color: black;
 	height: 530px;
 }

--- a/src/components/EnactLiveEdit.module.less
+++ b/src/components/EnactLiveEdit.module.less
@@ -3,12 +3,12 @@
 
 .dropdownAgate {
 	background-color: white;
-	height: 530px;
+	height: 531px;
 }
 
 .dropdownSandstoneMoonstone {
 	background-color: black;
-	height: 530px;
+	height: 531px;
 }
 
 .frame {

--- a/src/components/EnactLiveEdit.module.less
+++ b/src/components/EnactLiveEdit.module.less
@@ -1,6 +1,11 @@
 // EnactLiveEdit.less
 //
 
+.dropdown {
+	background-color: black;
+	height: 530px;
+}
+
 .frame {
 	border: none;
 	width: 100%;


### PR DESCRIPTION
### Checklist 

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Components `Checkbox` and `Dropdown` are cut off in the example.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added padding so the components are not cut off on the left/top side in the `iframe`. 
Changed the `iframe` height when the `Dropdown` is displayed to be fully visible.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Note: In Sandstone/Dropdown, there is a lot of space between the items in the DropdownList. We think this is caused by the Dropdown being in an iframe and the resolution independence mechanism not being applied well when the dropdown is opened. All the dimensions look to be fit for 4k resolution

### Links
[//]: # (Related issues, references)
WRP-10246

### Comments

Enact-DCO-1.0-Signed-off-by: Ion Andrusciac ion.andrusciac@lgepartner.com