### PR TITLE
WRP-12255: Modify description of minimum node version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+The following is a curated list of changes in the Enact docs-utils module, newest changes on the top.
+
+## [unreleased]
+
+- Changed to require node 14 or later
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ files and in-line documentation in JSDoc-style format.
 
 ## Building
 
-> Note: Requires Node 10.10+
+> Note: Requires Node 14+
 
 Before serving or building documentation, you must first run the `parse` command to generate the
 documentation from the Enact source:
@@ -32,10 +32,6 @@ To produce the final documentation, build a static site with the `build` command
 ```
 npm run build
 ```
-
-## Caveats
-
-Doc building currently only works on Mac or Linux filesystems.
 
 ## Linking Enact and Related Libraries
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Enact JavaScript Framework Docs",
   "version": "4.0.1",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=14"
   },
   "dependencies": {
     "@enact/core": "^4.6.0",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Documents related to docs need to be updated for minimum node version requirements. 
Because docs has its dependency updated to docs-utils 0.4.x with documentationjs 14.0.0 or higher

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update CHANGLOG.md, README.md and package.json to announce the minimum node version.
Deleted caveats as it builds on windows as well.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRP-12255

### Comments
Enact-DCO-1.0-Signed-off-by: SJ RO (sj.ro@lge.com)